### PR TITLE
Fix type-o in HTML modifications section

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Currently, the process requires 3 simple changes to your CMV application. I anti
         ```
         All widget-specific stylesheets will be loaded above this stylesheet in the HEAD.
 
-    - Add stylesheets to help the cmv and cmv themes co-exist:
+    - Add stylesheets to help the CMV and JIMU themes co-exist:
         ``` html
         <!-- needed so that jimu styles play nice with cmv -->
         <link rel="stylesheet" type="text/css" href="./css/cmv-jimu.css">


### PR DESCRIPTION
CMV and JIMU theme stylesheets need a shim to co-exist happily.  The README previously read "CMV and CMV themes".  Also fix CMV capitalization - should JIMU also be capitalized?